### PR TITLE
Updated fast-xml-parser version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1161,6 +1161,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -4167,9 +4168,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
-      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
       "funding": [
         {
           "type": "github",
@@ -4178,7 +4179,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "~5.4.5"
   },
   "overrides": {
-    "fast-xml-parser": "5.3.4",
+    "fast-xml-parser": "5.3.6",
     "undici": "6.23.0"
   }
 }


### PR DESCRIPTION

Issue#[1](https://github.com/aws-actions/aws-elasticbeanstalk-deploy/security/dependabot/1)

*Description of changes:* Updated fast-xml-parser version to 5.3.6


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.