### PR TITLE
fix: align max-retries code default with action.yml and README

### DIFF
--- a/src/__tests__/validations.test.ts
+++ b/src/__tests__/validations.test.ts
@@ -258,7 +258,7 @@ describe('Validation Functions', () => {
 
       expect(result.valid).toBe(true);
       expect(result.deploymentTimeout).toBe(900);
-      expect(result.maxRetries).toBe(3);
+      expect(result.maxRetries).toBe(2);
       expect(result.retryDelay).toBe(5);
     });
 

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -54,7 +54,7 @@ function validateRequiredInputs() {
 
 function validateNumericInputs() {
   const deploymentTimeoutInput = core.getInput('deployment-timeout') || '900';
-  const maxRetriesInput = core.getInput('max-retries') || '3';
+  const maxRetriesInput = core.getInput('max-retries') || '2';
   const retryDelayInput = core.getInput('retry-delay') || '5';
 
   const deploymentTimeout = parseInt(deploymentTimeoutInput, 10);


### PR DESCRIPTION
## Problem

There is a three-way mismatch on the `max-retries` default value:

| Source | Value |
|--------|-------|
| `action.yml` `default:` | `2` |
| README documentation | `2` |
| Code fallback (`validations.ts:57`) | `3` |

In a normal GitHub Actions run the `action.yml` default is always injected, so `'3'` never fires. But in non-standard invocations (local testing, third-party harnesses) the code fallback takes effect and silently overrides the documented behavior.

## Fix

Change the code fallback from `'3'` to `'2'` so all three sources agree.

## Changes

- `src/validations.ts` — `|| '3'` → `|| '2'`
- `src/__tests__/validations.test.ts` — update the "should use default values" assertion to expect `2`