### PR TITLE
feat: validate version-label length against AWS 1–100 character limit

### DIFF
--- a/src/__tests__/validations.test.ts
+++ b/src/__tests__/validations.test.ts
@@ -307,6 +307,46 @@ describe('Validation Functions', () => {
       expect(result.applicationVersionLabel).toBe('test-sha-123');
     });
 
+    it('should fail validation when version-label exceeds 100 characters', () => {
+      const longLabel = 'a'.repeat(101);
+      mockedCore.getInput.mockImplementation((name: string) => {
+        const inputs: Record<string, string> = {
+          'aws-region': 'us-east-1',
+          'application-name': 'test-app',
+          'environment-name': 'test-env',
+          'solution-stack-name': '64bit Amazon Linux 2',
+          'version-label': longLabel,
+        };
+        return inputs[name] || '';
+      });
+      mockedCore.getBooleanInput.mockReturnValue(false);
+
+      const result = validateAllInputs();
+
+      expect(result.valid).toBe(false);
+      expect(mockedCore.setFailed).toHaveBeenCalledWith(expect.stringContaining('version-label must be between 1 and 100 characters'));
+    });
+
+    it('should pass validation when version-label is exactly 100 characters', () => {
+      const exactLabel = 'a'.repeat(100);
+      mockedCore.getInput.mockImplementation((name: string) => {
+        const inputs: Record<string, string> = {
+          'aws-region': 'us-east-1',
+          'application-name': 'test-app',
+          'environment-name': 'test-env',
+          'solution-stack-name': '64bit Amazon Linux 2',
+          'version-label': exactLabel,
+        };
+        return inputs[name] || '';
+      });
+      mockedCore.getBooleanInput.mockReturnValue(false);
+
+      const result = validateAllInputs();
+
+      expect(result.valid).toBe(true);
+      expect(result.applicationVersionLabel).toBe(exactLabel);
+    });
+
     it('should fail validation for invalid JSON in option-settings', () => {
       mockedCore.getInput.mockImplementation((name: string) => {
         const inputs: Record<string, string> = {

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -121,6 +121,12 @@ function validateOptionalInputs() {
   const s3BucketName = core.getInput('s3-bucket-name') || undefined;
   const optionSettings = core.getInput('option-settings') || undefined;
 
+  // AWS enforces a 1–100 character limit on version labels
+  if (applicationVersionLabel.length < 1 || applicationVersionLabel.length > 100) {
+    core.setFailed(`version-label must be between 1 and 100 characters, got ${applicationVersionLabel.length}: "${applicationVersionLabel}"`);
+    return { valid: false };
+  }
+
   // Validate option-settings is valid JSON array if provided
   if (optionSettings) {
     try {


### PR DESCRIPTION
## Problem

AWS enforces a **1–100 character** limit on application version labels. Auto-generated labels (`GITHUB_SHA` = 40 chars, `` v`date` `` = 14 chars) are always within range, but user-supplied labels are not validated. A label exceeding 100 characters currently passes through to AWS and returns a cryptic API error rather than a clear validation message.

## Fix

Add a length check in `validateOptionalInputs` immediately after the version label is determined:

```ts
if (applicationVersionLabel.length < 1 || applicationVersionLabel.length > 100) {
  core.setFailed(`version-label must be between 1 and 100 characters, got ${applicationVersionLabel.length}: "${applicationVersionLabel}"`);
  return { valid: false };
}
```

## Changes

- `src/validations.ts` — add length validation for `version-label`
- `src/__tests__/validations.test.ts` — add two new tests: label > 100 chars fails, label exactly 100 chars passes