### PR TITLE
fix: add missing git user.email so the package workflow can commit dist/

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Package
         run: |
           npm ci
@@ -24,7 +25,8 @@ jobs:
           npm run build
       - name: Commit
         run: |
-          git config --global user.name "GitHub Actions"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add dist/
-          git commit -m "(chore) updating dist" || echo "No changes to commit"
+          git diff --staged --quiet || git commit -m "(chore) updating dist"
           git push origin HEAD:main


### PR DESCRIPTION
## Problem

The `package.yml` workflow was failing to commit the rebuilt `dist/` folder after every push to `main`, so the bundled action was always stale.

**Root cause:** `git commit` requires both `user.name` *and* `user.email`. The workflow only configured `user.name`. When git tried to create the commit it exited with an error — but that error was swallowed by `|| echo "No changes to commit"`, making the failure invisible. The subsequent `git push` then pushed nothing (no new commit existed).

## Changes

**`package.yml`**

1. Add the missing `git config --global user.email "github-actions[bot]@users.noreply.github.com"`
2. Use the canonical bot identity (`github-actions[bot]`) for `user.name` — consistent with GitHub's standard bot display
3. Replace the silent `|| echo` guard with `git diff --staged --quiet || git commit ...` so that if commit *does* fail for another reason (e.g. permissions), the workflow step exits non-zero and the failure is visible
4. Pass `token: ${{ secrets.GITHUB_TOKEN }}` explicitly to `actions/checkout` so the remote is configured for authenticated push before any git operations run

## Before / After

```yaml
# Before
git config --global user.name "GitHub Actions"
git add dist/
git commit -m "(chore) updating dist" || echo "No changes to commit"
git push origin HEAD:main

# After
git config --global user.name "github-actions[bot]"
git config --global user.email "github-actions[bot]@users.noreply.github.com"
git add dist/
git diff --staged --quiet || git commit -m "(chore) updating dist"
git push origin HEAD:main
```