### PR TITLE
security: add default exclusions for sensitive files in deployment packages

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -178,9 +178,9 @@ describe('Main Functions', () => {
       // Verify the mock archive methods were called
       const mockArchiveInstance = archiver();
       expect(mockArchiveInstance.pipe).toHaveBeenCalled();
-      expect(mockArchiveInstance.glob).toHaveBeenCalledWith('**/*', { 
+      expect(mockArchiveInstance.glob).toHaveBeenCalledWith('**/*', {
         dot: true,
-        ignore: ['*.git*', '*.node*'] 
+        ignore: expect.arrayContaining(['*.git*', '*.node*', '.git/**', '.env', '.env.*', '**/*.pem', '**/*.key'])
       });
       expect(mockArchiveInstance.finalize).toHaveBeenCalled();
     });


### PR DESCRIPTION
## Problem

When the action auto-creates a deployment package from the workspace (no `deployment-package-path`), it uses `dot: true` with `archiver.glob()` which includes **all** hidden files. Without explicit `exclude-patterns`, the action will package everything in the workspace including:

- `.env` / `.env.*` files with secrets
- `.git/` directory (potentially containing credentials in config)
- `*.pem` / `*.key` private keys
- `.aws/` credentials directory
- `.ssh/` keys
- `.npmrc` with registry tokens

These files end up in the deployment artifact uploaded to S3 and deployed to Elastic Beanstalk instances.

## Fix

Add hardcoded default exclusion patterns for known sensitive file types. These are always applied when auto-creating a package and are merged with any user-provided `exclude-patterns`.

Users who provide their own `deployment-package-path` are unaffected since the action uses their pre-built archive as-is.

### Default exclusions added:
- `.git/**`
- `.env`, `.env.*`
- `**/*.pem`, `**/*.key`
- `.aws/**`, `.ssh/**`
- `.npmrc`

## Changes

- `src/deploymentpackage.ts` — add `DEFAULT_EXCLUDE_PATTERNS` constant, merge with user patterns in `createZipFile`
- `src/__tests__/main.test.ts` — update glob assertion to verify default patterns are included

## Test plan

- [x] Default exclusions are applied when creating packages
- [x] User-provided exclude-patterns are preserved alongside defaults
- [x] All 85 tests pass