### PR TITLE
security: add ExpectedBucketOwner to S3 PutObject upload

### DIFF
--- a/src/aws-operations.ts
+++ b/src/aws-operations.ts
@@ -330,6 +330,7 @@ export async function uploadToS3(
         Key: key,
         Body: fs.createReadStream(packagePath),
         ContentLength: fileSizeBytes,
+        ExpectedBucketOwner: accountId,
       });
 
       await clients.getS3Client().send(command);


### PR DESCRIPTION
## Problem

The `PutObjectCommand` used to upload deployment packages to S3 does not include the `ExpectedBucketOwner` header. If the `s3-bucket-name` input is misconfigured (or an attacker pre-creates a bucket with the predictable default name `elasticbeanstalk-<region>-<account-id>`), deployment packages could be uploaded to a bucket owned by a different AWS account.

While `verifyBucketOwnership` checks the ACL before upload when `create-s3-bucket-if-not-exists` is false, the actual `PutObject` call itself does not enforce ownership — a TOCTOU gap exists.

## Fix

Add `ExpectedBucketOwner: accountId` to the `PutObjectCommand`. S3 will reject the upload with a 403 if the bucket is not owned by the expected account, closing the TOCTOU gap.

## Changes

- `src/aws-operations.ts` — add `ExpectedBucketOwner` to `PutObjectCommand` params

## Test plan

- [x] All 85 tests pass
- [x] Upload will now fail with 403 if bucket owner doesn't match caller's account