### PR TITLE
chore: security hardening for workflows, examples, and .gitignore

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,9 +12,9 @@ jobs:
     name: Run Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24.x
       - name: Run tests

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
           cache: 'npm'
@@ -42,14 +42,14 @@ jobs:
           cat action.yml.sha256
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: |
             dist/index.js
             action.yml
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           name: Release ${{ github.ref_name }}
           body: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 /node_modules
 /coverage
 .DS_Store
+.env
+.env.*
+*.pem
+*.key
+.aws/
+.ssh/

--- a/examples/corretto.yml
+++ b/examples/corretto.yml
@@ -13,12 +13,15 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up JDK Corretto
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '21'
           distribution: 'corretto'
@@ -36,10 +39,9 @@ jobs:
           zip -r ../app.zip .
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Deploy to Elastic Beanstalk

--- a/examples/docker.yml
+++ b/examples/docker.yml
@@ -13,19 +13,21 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Create deployment package
         run: |
           zip -r app.zip Dockerfile Dockerrun.aws.json application.py
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Deploy to Elastic Beanstalk

--- a/examples/go.yml
+++ b/examples/go.yml
@@ -18,10 +18,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.21'
 
@@ -34,7 +34,7 @@ jobs:
           zip -r app.zip application Procfile public/ .ebextensions/
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}

--- a/examples/nodejs.yml
+++ b/examples/nodejs.yml
@@ -13,19 +13,21 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Create deployment package
         run: |
           zip -r app.zip app.js package.json index.html
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Deploy to Elastic Beanstalk

--- a/examples/python.yml
+++ b/examples/python.yml
@@ -18,14 +18,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Create deployment package
         run: |
           zip -r app.zip application.py requirements.txt
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Summary

Addresses several low/informational findings from a security code review.

### Pin GitHub Actions to commit SHAs (supply chain)

All third-party actions in CI workflows and examples are now pinned to full commit SHAs instead of mutable version tags. This prevents supply chain attacks where a maintainer (or compromised account) force-pushes a tag to point to malicious code.

**Pinned actions:**
- `actions/checkout` → `34e114876b...` (v4)
- `actions/setup-node` → `49933ea528...` (v4)
- `actions/setup-java` → `c1e323688f...` (v4)
- `actions/setup-go` → `40f1582b24...` (v5)
- `actions/attest-build-provenance` → `e8998f9491...` (v2)
- `softprops/action-gh-release` → `a06a81a03e...` (v2)
- `aws-actions/configure-aws-credentials` → `7474bc4690...` (v4)

### Switch examples to OIDC authentication

The `nodejs.yml`, `docker.yml`, and `corretto.yml` examples previously used static AWS credentials (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`). These are now updated to use OIDC `role-to-assume`, matching the pattern already used by `python.yml` and `go.yml`.

### Add permissions blocks to all examples

Added explicit `permissions: { id-token: write, contents: read }` to the three examples that were missing them.

### Harden .gitignore

Added patterns for sensitive files that contributors could accidentally commit:
- `.env`, `.env.*`
- `*.pem`, `*.key`
- `.aws/`, `.ssh/`

## Test plan

- [x] No source code changes — CI workflows and examples only
- [x] All SHA pins verified against current tag heads