### PR TITLE
fix: use GitHub App token in package workflow to bypass branch ruleset

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,44 +5,31 @@ on:
 
 name: Package
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   check:
     name: Package distribution file
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
-          fetch-depth: 0
-      - name: Setup branch
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          BRANCH_NAME="chore/update-dist"
-          if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
-            git checkout "$BRANCH_NAME"
-            git merge main --no-edit
-          else
-            git checkout -b "$BRANCH_NAME"
-          fi
+          token: ${{ steps.app-token.outputs.token }}
       - name: Package
         run: |
           npm ci
           npm test
           npm run build
-      - name: Create Pull Request
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit
         run: |
-          BRANCH_NAME="chore/update-dist"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add dist/
           git diff --staged --quiet || git commit -m "(chore) updating dist"
-          git push origin "$BRANCH_NAME"
-          if ! gh pr list --head "$BRANCH_NAME" --state open | grep -q .; then
-            gh pr create --title "(chore) Update dist" --body "Automated PR to update the dist folder." --base main
-          fi
+          git push origin HEAD:main


### PR DESCRIPTION
## Summary

- Replace the PR-based `dist/` update workaround with a GitHub App token approach
- The `package.yml` workflow now uses `actions/create-github-app-token` to generate a short-lived token that can push directly to `main` as a ruleset bypass actor
- Removes the `chore/update-dist` branch logic, `pull-requests: write` permission, and `fetch-depth: 0`

## Context

The default `GITHUB_TOKEN` cannot push to `main` due to repository rulesets (GH013). The previous PR-based workaround (#26) still required manual review to merge, defeating the purpose of automation.

A GitHub App has been added as a bypass actor on the branch ruleset, allowing the workflow to push `dist/` updates directly.

## Test plan

- [ ] Merge this PR and push a source change to `main`
- [ ] Confirm the `Package` workflow succeeds and commits updated `dist/` to `main`