### PR TITLE
fix: skip package workflow when triggered by app bot push

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -9,6 +9,7 @@ jobs:
   check:
     name: Package distribution file
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'aws-eb-actions-bot[bot]' }}
     steps:
       - name: Generate GitHub App token
         id: app-token


### PR DESCRIPTION
## Summary

- Add `if: ${{ github.actor != 'aws-eb-actions-bot[bot]' }}` to the package job
- Prevents a redundant no-op workflow run when the bot pushes the `dist/` commit to `main`

## Context

Pushes made with a GitHub App token trigger workflow runs (unlike `GITHUB_TOKEN`). Without this check, every `dist/` commit from the bot triggers `package.yml` again — it rebuilds, finds no changes, and exits. Harmless but wastes CI minutes.

## Test plan

- [ ] Push a source change to `main`
- [ ] Confirm the `Package` workflow runs once (for the source push) and skips the second run (for the bot's `dist/` push)