### PR TITLE
fix(release): don't re-trigger workflow on floating major-version tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release with Artifact Attestation
 on:
   push:
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - 'v*.*.*' # Only vX.Y.Z release tags; excludes floating major tags like v1
 
 permissions:
   contents: write      # Create releases


### PR DESCRIPTION
## Summary
  
  The release workflow was triggered a second time after each release when the  "Update major version tag" step pushed the floating `v1` tag — because the  push filter `v*` matched `v1` too. Observed on the v1.0.6 release:

  - 19:22 UTC: `v1.0.6` push → release workflow (intended) ✅
  - 19:30 UTC: `v1` push → release workflow (redundant, had to be cancelled manually)

  ## Change

  Tighten the tag filter from `v*` to `v*.*.*` so the workflow only runs for stable `vX.Y.Z` release tags. Floating tags (`v1`, `v2`, ...) no longer match.

