### PR TITLE
 feat: add verbose-logging toggle to mask sensitive identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ This enables managed platform updates and configures Elastic Beanstalk to automa
 | `create-s3-bucket-if-not-exists` | Create S3 bucket if it doesn't exist | `true` |
 | `s3-bucket-name` | Custom S3 bucket name for deployment packages | `elasticbeanstalk-{region}-{accountId}` |
 | `exclude-patterns` | Comma-separated glob patterns to exclude from auto-created packages | None |
+| `verbose-logging` | Show infrastructure identifiers (account ID, bucket names, environment names, version labels) in logs. When `false`, identifiers are masked and event details are suppressed. | `false` |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,10 @@ inputs:
   option-settings:
     description: 'Elastic Beanstalk option settings as JSON array. Required when creating a new environment - MUST include IAM settings: [{"Namespace":"aws:autoscaling:launchconfiguration","OptionName":"IamInstanceProfile","Value":"your-instance-profile"},{"Namespace":"aws:elasticbeanstalk:environment","OptionName":"ServiceRole","Value":"your-service-role"}]'
     required: false
+  verbose-logging:
+    description: 'When true, infrastructure identifiers (account ID, bucket names, environment names, version labels, region) are shown in logs. When false, they are masked.'
+    required: false
+    default: 'false'
 
 outputs:
   environment-url:

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -4,6 +4,7 @@ jest.mock('@actions/core', () => ({
   getBooleanInput: jest.fn(),
   setFailed: jest.fn(),
   setOutput: jest.fn(),
+  setSecret: jest.fn(),
   info: jest.fn(),
   warning: jest.fn(),
   error: jest.fn(),
@@ -103,7 +104,7 @@ import {
   createEnvironment,
   getEnvironmentInfo,
 } from '../aws-operations';
-import { waitForDeploymentCompletion, waitForHealthRecovery } from '../monitoring';
+import { waitForDeploymentCompletion, waitForHealthRecovery, sanitizeResourceIdentifiers } from '../monitoring';
 import { AWSClients } from '../aws-clients';
 
 const mockedCore = core as jest.Mocked<typeof core>;
@@ -152,6 +153,7 @@ describe('Main Functions', () => {
     });
     mockedCore.getBooleanInput.mockImplementation((name: string) => {
       if (name === 'create-s3-bucket-if-not-exists') return true;
+      if (name === 'verbose-logging') return true;
       return false;
     });
   });
@@ -413,7 +415,7 @@ describe('Main Functions', () => {
       mockSend.mockResolvedValue({
         Environments: [{ Status: 'Ready' }],
       });
-      await waitForDeploymentCompletion(mockClients, 'app', 'env', 900);
+      await waitForDeploymentCompletion(mockClients, 'app', 'env', 900, true);
       expect(mockSend).toHaveBeenCalled();
     });
   });
@@ -423,7 +425,7 @@ describe('Main Functions', () => {
       mockSend.mockResolvedValue({
         Environments: [{ Health: 'Green', Status: 'Ready' }],
       });
-      await waitForHealthRecovery(mockClients, 'app', 'env', 900);
+      await waitForHealthRecovery(mockClients, 'app', 'env', 900, true);
       expect(mockSend).toHaveBeenCalled();
     });
 
@@ -431,7 +433,7 @@ describe('Main Functions', () => {
       mockSend.mockResolvedValue({
         Environments: [{ Health: 'Yellow', Status: 'Ready' }],
       });
-      await waitForHealthRecovery(mockClients, 'app', 'env', 900);
+      await waitForHealthRecovery(mockClients, 'app', 'env', 900, true);
       expect(mockSend).toHaveBeenCalled();
     });
 
@@ -449,7 +451,7 @@ describe('Main Functions', () => {
             }
           ]
         });
-      await expect(waitForHealthRecovery(mockClients, 'app', 'env', 1))
+      await expect(waitForHealthRecovery(mockClients, 'app', 'env', 1, true))
         .rejects.toThrow('Environment health recovery failed - health is Red');
     });
 
@@ -463,8 +465,45 @@ describe('Main Functions', () => {
           Environments: [{ Health: 'Red', Status: 'Updating' }],
         });
       });
-      await expect(waitForHealthRecovery(mockClients, 'app', 'env', 1))
+      await expect(waitForHealthRecovery(mockClients, 'app', 'env', 1, true))
         .rejects.toThrow('Environment health recovery timed out after 1s');
+    });
+  });
+
+  describe('sanitizeResourceIdentifiers', () => {
+    it('should mask EC2 instance IDs', () => {
+      expect(sanitizeResourceIdentifiers('Failed on i-0a1b2c3d4e5f67890'))
+        .toBe('Failed on ***');
+    });
+
+    it('should mask security group IDs', () => {
+      expect(sanitizeResourceIdentifiers('Created security group named: sg-0a1b2c3d4e5f67890'))
+        .toBe('Created security group named: ***');
+    });
+
+    it('should mask ARNs', () => {
+      expect(sanitizeResourceIdentifiers('Policy: arn:aws:autoscaling:us-west-2:000000000000:scalingPolicy:example'))
+        .toBe('Policy: ***');
+    });
+
+    it('should mask EB-generated resource names', () => {
+      expect(sanitizeResourceIdentifiers('Created: awseb-e-abcdefghij-stack-AWSEBAutoScalingGroup-EXAMPLE123'))
+        .toBe('Created: ***');
+    });
+
+    it('should mask IP addresses', () => {
+      expect(sanitizeResourceIdentifiers('Connected to 10.0.0.1'))
+        .toBe('Connected to ***');
+    });
+
+    it('should mask multiple identifiers in one message', () => {
+      expect(sanitizeResourceIdentifiers('Instance i-0a1b2c3d4e5f67890 in sg-0f9e8d7c6b5a43210 failed'))
+        .toBe('Instance *** in *** failed');
+    });
+
+    it('should leave non-sensitive text unchanged', () => {
+      expect(sanitizeResourceIdentifiers('Deployment completed successfully'))
+        .toBe('Deployment completed successfully');
     });
   });
 
@@ -536,6 +575,70 @@ describe('Main Functions', () => {
       expect(mockedCore.setOutput).toHaveBeenCalledWith('environment-id', 'e-123');
       expect(mockedCore.setOutput).toHaveBeenCalledWith('deployment-action-type', 'update');
       expect(mockedCore.setOutput).toHaveBeenCalledWith('version-label', 'v1.0.0');
+    });
+
+    it('should mask sensitive identifiers when verbose-logging is false', async () => {
+      mockedCore.getBooleanInput.mockImplementation((name: string) => {
+        if (name === 'create-s3-bucket-if-not-exists') return true;
+        if (name === 'verbose-logging') return false;
+        return false;
+      });
+
+      // With useExistingApplicationVersionIfAvailable = false, applicationVersionExists is skipped
+      // Call sequence: STS -> HeadBucket -> PutObject -> CreateAppVersion -> DescribeEnvs -> UpdateEnv -> GetEnvInfo
+      mockSend.mockImplementation(() => {
+        const callCount = mockSend.mock.calls.length;
+
+        if (callCount === 1) return Promise.resolve({ Account: '123456789012' });
+        if (callCount === 2) return Promise.resolve({});  // HeadBucket
+        if (callCount === 3) return Promise.resolve({});  // PutObject
+        if (callCount === 4) return Promise.resolve({});  // CreateAppVersion
+        if (callCount === 5) return Promise.resolve({ Environments: [{ Status: 'Ready', Health: 'Green' }] });
+        if (callCount === 6) return Promise.resolve({});  // UpdateEnvironment
+        if (callCount === 7) return Promise.resolve({ Environments: [{ CNAME: 'test.com', EnvironmentId: 'e-123', Status: 'Ready', Health: 'Green' }] });
+
+        return Promise.resolve({});
+      });
+
+      await run();
+
+      expect(mockedCore.setFailed).not.toHaveBeenCalled();
+      expect((mockedCore as any).setSecret).toHaveBeenCalledWith('123456789012');
+      expect((mockedCore as any).setSecret).toHaveBeenCalledWith('test-app');
+      expect((mockedCore as any).setSecret).toHaveBeenCalledWith('test-env');
+      expect((mockedCore as any).setSecret).toHaveBeenCalledWith('v1.0.0');
+      // Outputs are still set (masking is handled by the runner, not by withholding outputs)
+      expect(mockedCore.setOutput).toHaveBeenCalledWith('environment-url', 'test.com');
+      expect(mockedCore.setOutput).toHaveBeenCalledWith('environment-id', 'e-123');
+      expect(mockedCore.setOutput).toHaveBeenCalledWith('version-label', 'v1.0.0');
+    });
+
+    it('should not mask identifiers when verbose-logging is true', async () => {
+      mockedCore.getBooleanInput.mockImplementation((name: string) => {
+        if (name === 'create-s3-bucket-if-not-exists') return true;
+        if (name === 'verbose-logging') return true;
+        return false;
+      });
+
+      // With useExistingApplicationVersionIfAvailable = false, applicationVersionExists is skipped
+      mockSend.mockImplementation(() => {
+        const callCount = mockSend.mock.calls.length;
+
+        if (callCount === 1) return Promise.resolve({ Account: '123456789012' });
+        if (callCount === 2) return Promise.resolve({});  // HeadBucket
+        if (callCount === 3) return Promise.resolve({});  // PutObject
+        if (callCount === 4) return Promise.resolve({});  // CreateAppVersion
+        if (callCount === 5) return Promise.resolve({ Environments: [{ Status: 'Ready', Health: 'Green' }] });
+        if (callCount === 6) return Promise.resolve({});  // UpdateEnvironment
+        if (callCount === 7) return Promise.resolve({ Environments: [{ CNAME: 'test.com', EnvironmentId: 'e-123', Status: 'Ready', Health: 'Green' }] });
+
+        return Promise.resolve({});
+      });
+
+      await run();
+
+      expect(mockedCore.setFailed).not.toHaveBeenCalled();
+      expect((mockedCore as any).setSecret).not.toHaveBeenCalled();
     });
 
     it('should create new environment when create-environment-if-not-exists is true', async () => {

--- a/src/aws-operations.ts
+++ b/src/aws-operations.ts
@@ -135,7 +135,6 @@ export async function retryWithBackoff<T>(
 
   const retryWord = maxRetries === 1 ? 'retry' : 'retries';
   const errorMessage = `${operationName} failed after ${totalAttempts} attempts (${maxRetries} ${retryWord}): ${lastError?.message}`;
-  core.error(errorMessage);
   throw new Error(errorMessage);
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,10 +14,13 @@ import {
   getEnvironmentInfo,
   validateOptionSettingsForCreate,
 } from './aws-operations';
-import { waitForDeploymentCompletion, waitForHealthRecovery } from './monitoring';
+import { waitForDeploymentCompletion, waitForHealthRecovery, sanitizeResourceIdentifiers } from './monitoring';
 
 export async function run(): Promise<void> {
   const startTime = Date.now();
+  // Hoisted so the catch block can sanitize error messages.
+  // Defaults to false (quiet) if an error is thrown before inputs are parsed.
+  let verboseLogging = false;
 
   try {
     core.info('🚀 Starting Elastic Beanstalk deployment...');
@@ -35,6 +38,14 @@ export async function run(): Promise<void> {
       useExistingApplicationVersionIfAvailable, createS3BucketIfNotExists, s3BucketName, cnamePrefix, excludePatterns,
       optionSettings
     } = inputs as Inputs;
+    verboseLogging = (inputs as Inputs).verboseLogging;
+
+    if (!verboseLogging) {
+      core.setSecret(applicationName);
+      core.setSecret(environmentName);
+      core.setSecret(applicationVersionLabel);
+      if (s3BucketName) core.setSecret(s3BucketName);
+    }
 
     core.startGroup('📋 Validating inputs');
     core.info(`Application: ${applicationName}`);
@@ -50,6 +61,10 @@ export async function run(): Promise<void> {
     const accountId = await getAwsAccountId(clients, maxRetries, retryDelay);
     core.info('✅ AWS account verified');
     core.endGroup();
+
+    if (!verboseLogging) {
+      core.setSecret(accountId);
+    }
 
     core.startGroup('📦 Creating deployment package');
     const { path: packagePath } = await createDeploymentPackage(
@@ -164,16 +179,21 @@ export async function run(): Promise<void> {
     let lastSeenEventDate: Date | undefined;
     if (waitForDeployment) {
       core.startGroup('⏳ Waiting for deployment');
-      lastSeenEventDate = await waitForDeploymentCompletion(clients, applicationName, environmentName, deploymentTimeout, deploymentActionType, deploymentStartTime);
+      lastSeenEventDate = await waitForDeploymentCompletion(clients, applicationName, environmentName, deploymentTimeout, verboseLogging, deploymentActionType, deploymentStartTime);
       core.endGroup();
     }
     if (waitForEnvironmentRecovery) {
       core.startGroup('🏥 Waiting for environment health');
-      await waitForHealthRecovery(clients, applicationName, environmentName, deploymentTimeout, deploymentStartTime, lastSeenEventDate);
+      await waitForHealthRecovery(clients, applicationName, environmentName, deploymentTimeout, verboseLogging, deploymentStartTime, lastSeenEventDate);
       core.endGroup();
     }
 
     const envInfo = await getEnvironmentInfo(clients, applicationName, environmentName);
+
+    if (!verboseLogging) {
+      core.setSecret(envInfo.url);
+      core.setSecret(envInfo.id);
+    }
 
     core.setOutput('environment-url', envInfo.url);
     core.setOutput('environment-id', envInfo.id);
@@ -183,7 +203,7 @@ export async function run(): Promise<void> {
     core.setOutput('version-label', applicationVersionLabel);
 
     const totalTime = Math.round((Date.now() - startTime) / 1000);
-    
+
     core.startGroup('📤 Deployment Outputs');
     core.info(`Environment URL: ${envInfo.url}`);
     core.info(`Environment ID: ${envInfo.id}`);
@@ -197,8 +217,11 @@ export async function run(): Promise<void> {
 
   } catch (error) {
     const totalTime = Math.round((Date.now() - startTime) / 1000);
-    core.error(`❌ Deployment failed after ${totalTime}s: ${(error as Error).message}`);
-    core.setFailed(`Deployment failed: ${(error as Error).message}`);
+    const errorMessage = verboseLogging
+      ? (error as Error).message
+      : sanitizeResourceIdentifiers((error as Error).message);
+    core.error(`❌ Deployment failed after ${totalTime}s: ${errorMessage}`);
+    core.setFailed(`Deployment failed: ${errorMessage}`);
   }
 }
 

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -6,12 +6,47 @@ import {
 import { AWSClients } from './aws-clients';
 
 /**
+ * Strip dynamic AWS resource identifiers from a message.
+ * Used to sanitize error messages when verbose logging is disabled.
+ */
+export function sanitizeResourceIdentifiers(message: string): string {
+  return message
+    // EC2 instance IDs: i-0abc123def
+    .replace(/\bi-[0-9a-f]{8,17}\b/g, '***')
+    // Security group IDs: sg-0abc123def
+    .replace(/\bsg-[0-9a-f]{8,17}\b/g, '***')
+    // ENI IDs: eni-0abc123
+    .replace(/\beni-[0-9a-f]{8,17}\b/g, '***')
+    // Subnet IDs: subnet-0abc123
+    .replace(/\bsubnet-[0-9a-f]{8,17}\b/g, '***')
+    // VPC IDs: vpc-0abc123
+    .replace(/\bvpc-[0-9a-f]{8,17}\b/g, '***')
+    // Launch template IDs: lt-0abc123def
+    .replace(/\blt-[0-9a-f]{8,17}\b/g, '***')
+    // EBS volume IDs: vol-0abc123def
+    .replace(/\bvol-[0-9a-f]{8,17}\b/g, '***')
+    // Elastic IP allocation IDs: eipalloc-0abc123
+    .replace(/\beipalloc-[0-9a-f]{8,17}\b/g, '***')
+    // NAT gateway IDs: nat-0abc123
+    .replace(/\bnat-[0-9a-f]{8,17}\b/g, '***')
+    // EB-generated resource names: awseb-e-xxx-AWSEBLoa-xxx (must precede env ID pattern)
+    .replace(/\bawseb-[a-zA-Z0-9_-]+\b/g, '***')
+    // EB environment IDs: e-abcdefghij
+    .replace(/\be-[a-z0-9]{10,}\b/g, '***')
+    // ARNs: arn:aws:service:region:account:resource
+    .replace(/\barn:aws:[a-zA-Z0-9_/:.+*-]+\b/g, '***')
+    // IP addresses
+    .replace(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g, '***');
+}
+
+/**
  * Fetch recent environment events for debugging and check for fatal/error events
  */
 async function describeRecentEvents(
   clients: AWSClients,
   applicationName: string,
   environmentName: string,
+  verboseLogging: boolean,
   lastSeenEventDate?: Date,
   deploymentStartTime?: Date
 ): Promise<{ hasError: boolean; errorMessage?: string; lastEventDate?: Date }> {
@@ -44,20 +79,20 @@ async function describeRecentEvents(
 
       if (newEvents.length > 0) {
         // Only show header on first call
-        if (!lastSeenEventDate) {
+        if (verboseLogging && !lastSeenEventDate) {
           core.info('📋 Recent events:');
         }
-        
+
         // Sort events by timestamp in ascending order (oldest first)
         const sortedEvents = [...newEvents].sort((a, b) => {
           const dateA = a.EventDate?.getTime() || 0;
           const dateB = b.EventDate?.getTime() || 0;
           return dateA - dateB;
         });
-        
+
         const fatalOrErrorEvents: Array<{ message: string }> = [];
         let mostRecentDate: Date | undefined;
-        
+
         sortedEvents.forEach((event) => {
           const eventDate = event.EventDate;
           if (eventDate) {
@@ -66,18 +101,23 @@ async function describeRecentEvents(
               mostRecentDate = eventDate;
             }
           }
-          
-          const timestamp = eventDate?.toISOString() || 'Unknown time';
+
           const severity = event.Severity || 'INFO';
           const message = event.Message || 'No message';
 
           if (severity === 'ERROR' || severity === 'FATAL') {
-            core.error(`  [${timestamp}] ${severity}: ${message}`);
             fatalOrErrorEvents.push({ message });
-          } else if (severity === 'WARN') {
-            core.warning(`  [${timestamp}] ${severity}: ${message}`);
-          } else {
-            core.info(`  [${timestamp}] ${severity}: ${message}`);
+          }
+
+          if (verboseLogging) {
+            const timestamp = eventDate?.toISOString() || 'Unknown time';
+            if (severity === 'ERROR' || severity === 'FATAL') {
+              core.error(`  [${timestamp}] ${severity}: ${message}`);
+            } else if (severity === 'WARN') {
+              core.warning(`  [${timestamp}] ${severity}: ${message}`);
+            } else {
+              core.info(`  [${timestamp}] ${severity}: ${message}`);
+            }
           }
         });
 
@@ -85,7 +125,7 @@ async function describeRecentEvents(
           const errorMessage = fatalOrErrorEvents[0].message || 'Unknown error occurred';
           return { hasError: true, errorMessage, lastEventDate: mostRecentDate };
         }
-        
+
         return { hasError: false, lastEventDate: mostRecentDate };
       }
     }    
@@ -106,6 +146,7 @@ export async function waitForDeploymentCompletion(
   applicationName: string,
   environmentName: string,
   timeout: number,
+  verboseLogging: boolean,
   deploymentActionType?: 'create' | 'update',
   deploymentStartTime?: Date
 ): Promise<Date | undefined> {
@@ -137,6 +178,7 @@ export async function waitForDeploymentCompletion(
           clients,
           applicationName,
           environmentName,
+          verboseLogging,
           lastSeenEventDate,
           deploymentStartTime
         );
@@ -149,6 +191,7 @@ export async function waitForDeploymentCompletion(
         clients,
         applicationName,
         environmentName,
+        verboseLogging,
         lastSeenEventDate,
         deploymentStartTime
       );
@@ -172,7 +215,7 @@ export async function waitForDeploymentCompletion(
   }
 
   // Timeout occurred - fetch events to help diagnose
-  await describeRecentEvents(clients, applicationName, environmentName, lastSeenEventDate, deploymentStartTime);
+  await describeRecentEvents(clients, applicationName, environmentName, verboseLogging, lastSeenEventDate, deploymentStartTime);
   throw new Error(`Deployment timed out after ${timeout}s`);
 }
 
@@ -184,6 +227,7 @@ export async function waitForHealthRecovery(
   applicationName: string,
   environmentName: string,
   timeout: number,
+  verboseLogging: boolean,
   deploymentStartTime?: Date,
   lastEventDateFromDeployment?: Date
 ): Promise<void> {
@@ -218,6 +262,7 @@ export async function waitForHealthRecovery(
           clients,
           applicationName,
           environmentName,
+          verboseLogging,
           lastSeenEventDate,
           deploymentStartTime
         );
@@ -247,6 +292,6 @@ export async function waitForHealthRecovery(
   }
 
   // Timeout occurred - fetch events to help diagnose
-  await describeRecentEvents(clients, applicationName, environmentName, lastSeenEventDate, deploymentStartTime);
+  await describeRecentEvents(clients, applicationName, environmentName, verboseLogging, lastSeenEventDate, deploymentStartTime);
   throw new Error(`Environment health recovery timed out after ${timeout}s`);
 }

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -23,6 +23,7 @@ export interface Inputs {
   sourceDirectory?: string;
   excludePatterns: string;
   optionSettings?: string;
+  verboseLogging: boolean;
 }
 
 function validateRequiredInputs() {
@@ -158,6 +159,7 @@ function validateOptionalInputs() {
   const waitForEnvironmentRecovery = core.getBooleanInput('wait-for-environment-recovery');
   const useExistingApplicationVersionIfAvailable = core.getBooleanInput('use-existing-application-version-if-available');
   const createS3BucketIfNotExists = core.getBooleanInput('create-s3-bucket-if-not-exists');
+  const verboseLogging = core.getBooleanInput('verbose-logging');
 
   return {
     valid: true,
@@ -173,7 +175,8 @@ function validateOptionalInputs() {
     s3BucketName,
     cnamePrefix,
     excludePatterns,
-    optionSettings
+    optionSettings,
+    verboseLogging,
   };
 }
 
@@ -264,7 +267,8 @@ export function validateAllInputs(): { valid: boolean } & Partial<Inputs> {
     createS3BucketIfNotExists: optionalInputs.createS3BucketIfNotExists!,
     s3BucketName: optionalInputs.s3BucketName,
     excludePatterns: optionalInputs.excludePatterns!,
-    optionSettings: optionalInputs.optionSettings
+    optionSettings: optionalInputs.optionSettings,
+    verboseLogging: optionalInputs.verboseLogging!,
   };
 
   checkInputConflicts(validatedInputs);


### PR DESCRIPTION
  ## Summary

  - Adds a `verbose-logging` input (default `false`) that controls whether identifiers appear in action logs
  - When disabled, uses `core.setSecret()` to mask the application name, environment name, version label, account ID, S3 bucket name, environment URL, and environment ID in all log output
  - Suppresses EB deployment event detail lines (which contain dynamically-created resource names like security groups, load balancers, and instance IDs) when verbose logging is off
  - Error messages from failed deployments are passed through a sanitizer that strips AWS resource ID patterns (i-, sg-, eni-, subnet-, vpc-, lt-, vol-, eipalloc-, nat-, awseb-*, e- env IDs, ARNs, IP addresses) before reaching the user
  - All action outputs (environment-url, environment-id, version-label, etc.) are always set regardless of the toggle — downstream workflow steps are never broken

  ## Test plan

  - [x] Verify deployment succeeds with `verbose-logging: false` (default) and logs show `***` in place of identifiers
  - [x] Verify deployment succeeds with `verbose-logging: true` and logs show full identifiers as before
  - [x] Verify downstream steps can still read `environment-url` and other outputs when verbose logging is off
  - [x] Verify a failed deployment shows a sanitized error message without resource IDs when verbose logging is off